### PR TITLE
Fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # nagios-plugins-onedata
 
+[![Build Status](https://api.travis-ci.org/onedata/nagios-plugins-onedata.svg?branch=master)](https://travis-ci.org/onedata/nagios-plugins-onedata)
+
 This repository contains Nagios plugins for testing Onedata services availability,
 namely `Oneprovider` and `Onezone` services.
 

--- a/nagios-plugins-onedata.spec
+++ b/nagios-plugins-onedata.spec
@@ -9,6 +9,7 @@ Group: Network/Monitoring
 Source0: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
+Requires: bash
 Requires: curl
 Requires: libxml2
 %description

--- a/src/check_oneprovider
+++ b/src/check_oneprovider
@@ -157,7 +157,7 @@ fi
 # errors
 if [ "x$OVERALL_STATUS" != "xok" ]; then
     # Find the op_workers reporting errors
-    ERROR_WORKERS=$("${XMLLINT}" --shell "${TMP_FILE}" <<< 'xpath //healthdata/op_worker[@status="error"]/@name' 2>/dev/null | grep "content=" || echo)
+    ERROR_WORKERS=$("${XMLLINT}" --shell "${TMP_FILE}" <<< 'xpath //healthdata/op_worker[@status="error"]/@name' 2>/dev/null | grep "content=" | sed "s|content=||" | awk -v ORS=', ' '{print $1}' | sed 's/, $//' || echo)
 
     # Find the op_workers reporting out_of_sync
     OUTOFSYNC_WORKERS=$("${XMLLINT}" --shell "${TMP_FILE}" <<< 'xpath //healthdata/op_worker[@status="out_of_sync"]/@name' 2>/dev/null | grep "content=" || echo)

--- a/src/check_oneprovider
+++ b/src/check_oneprovider
@@ -1,5 +1,4 @@
-
-#!/bin/sh
+#!/bin/bash
 
 ##########################################################################
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/check_onezone
+++ b/src/check_onezone
@@ -153,7 +153,7 @@ fi
 if [ "x$OVERALL_STATUS" != "xok" ]; then
 
     # Find the op_workers reporting errors
-    ERROR_WORKERS=$(echo "$HEALTHDATA" | "$XMLLINT" --shell "${TMP_FILE}" <<< 'xpath //healthdata/oz_worker[@status="error"]/@name' 2>/dev/null | grep "content=" || echo)
+    ERROR_WORKERS=$(echo "$HEALTHDATA" | "$XMLLINT" --shell "${TMP_FILE}" <<< 'xpath //healthdata/oz_worker[@status="error"]/@name' 2>/dev/null | grep "content=" | sed "s|content=||" | awk -v ORS=', ' '{print $1}' | sed 's/, $//' || echo)
 
     # Find the op_workers reporting out_of_sync
     OUTOFSYNC_WORKERS=$(echo "$HEALTHDATA" | "$XMLLINT" --shell "${TMP_FILE}" <<< 'xpath //healthdata/oz_worker[@status="out_of_sync"]/@name' 2>/dev/null | grep "content=" || echo)

--- a/src/check_onezone
+++ b/src/check_onezone
@@ -1,5 +1,4 @@
-
-#!/bin/sh
+#!/bin/bash
 
 ##########################################################################
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
On my mac, tests/test.sh fails due to an incorrect output of failed workers (workers' names are prepend by content= and are separated by line returns).

This PR fixes the error workers output and make the tests pass.
It may probably be simplified, but at least it works.